### PR TITLE
Improved quickfix errors string matching for Gradle

### DIFF
--- a/compiler/gradle.vim
+++ b/compiler/gradle.vim
@@ -15,8 +15,8 @@ CompilerSet makeprg=gradle
 CompilerSet errorformat=
     \%E[ant:scalac]\ %f:%l:\ error:\ %m,
     \%W[ant:scalac]\ %f:%l:\ warning:\ %m,
-    \%E%.%#:compile%.%#Java%f:%l:\ error:\ %m,%-Z%p^,%-C%.%#,
-    \%W%.%#:compile%.%#Java%f:%l:\ warning:\ %m,%-Z%p^,%-C%.%#,
+    \%E%.%#:compile%\\w%#Java%f:%l:\ error:\ %m,%-Z%p^,%-C%.%#,
+    \%W%.%#:compile%\\w%#Java%f:%l:\ warning:\ %m,%-Z%p^,%-C%.%#,
     \%E%f:%l:\ error:\ %m,%-Z%p^,%-C%.%#,
     \%W%f:%l:\ warning:\ %m,%-Z%p^,%-C%.%#,
     \%E%f:\ %\\d%\\+:\ %m\ @\ line\ %l\\,\ column\ %c.,%-C%.%#,%Z%p^,

--- a/compiler/gradle.vim
+++ b/compiler/gradle.vim
@@ -15,14 +15,10 @@ CompilerSet makeprg=gradle
 CompilerSet errorformat=
     \%E[ant:scalac]\ %f:%l:\ error:\ %m,
     \%W[ant:scalac]\ %f:%l:\ warning:\ %m,
-    \%E:compileJava%f:%l:\ %m,
-    \%E:compileTestJava%f:%l:\ %m,
-    \%E%f:%l:\ %m,%-Z%p^,%-C%.%#,%-G%.%#,
+    \%E%.%#:compile%.%#Java%f:%l:\ error:\ %m,%-Z%p^,%-C%.%#,
+    \%W%.%#:compile%.%#Java%f:%l:\ warning:\ %m,%-Z%p^,%-C%.%#,
+    \%E%f:%l:\ error:\ %m,%-Z%p^,%-C%.%#,
+    \%W%f:%l:\ warning:\ %m,%-Z%p^,%-C%.%#,
     \%E%f:\ %\\d%\\+:\ %m\ @\ line\ %l\\,\ column\ %c.,%-C%.%#,%Z%p^,
     \%E%>%f:\ %\\d%\\+:\ %m,%C\ @\ line\ %l\\,\ column\ %c.,%-C%.%#,%Z%p^,
-    \%-G\\s%#,
-    \%-GBUILD\ SUCCESSFUL#,
-    \%-GTotal\ \time:\ %.%#,
-    \%E%f:%l:\ %m,
     \%-G%.%#
-

--- a/compiler/gradlew.vim
+++ b/compiler/gradlew.vim
@@ -15,14 +15,10 @@ CompilerSet makeprg=./gradlew
 CompilerSet errorformat=
     \%E[ant:scalac]\ %f:%l:\ error:\ %m,
     \%W[ant:scalac]\ %f:%l:\ warning:\ %m,
-    \%E:compileJava%f:%l:\ %m,
-    \%E:compileTestJava%f:%l:\ %m,
-    \%E%f:%l:\ %m,%-Z%p^,%-C%.%#,%-G%.%#,
+    \%E%.%#:compile%.%#Java%f:%l:\ error:\ %m,%-Z%p^,%-C%.%#,
+    \%W%.%#:compile%.%#Java%f:%l:\ warning:\ %m,%-Z%p^,%-C%.%#,
+    \%E%f:%l:\ error:\ %m,%-Z%p^,%-C%.%#,
+    \%W%f:%l:\ warning:\ %m,%-Z%p^,%-C%.%#,
     \%E%f:\ %\\d%\\+:\ %m\ @\ line\ %l\\,\ column\ %c.,%-C%.%#,%Z%p^,
     \%E%>%f:\ %\\d%\\+:\ %m,%C\ @\ line\ %l\\,\ column\ %c.,%-C%.%#,%Z%p^,
-    \%-G\\s%#,
-    \%-GBUILD\ SUCCESSFUL#,
-    \%-GTotal\ \time:\ %.%#,
-    \%E%f:%l:\ %m,
     \%-G%.%#
-

--- a/compiler/gradlew.vim
+++ b/compiler/gradlew.vim
@@ -25,3 +25,4 @@ CompilerSet errorformat=
     \%-GTotal\ \time:\ %.%#,
     \%E%f:%l:\ %m,
     \%-G%.%#
+

--- a/compiler/gradlew.vim
+++ b/compiler/gradlew.vim
@@ -15,8 +15,8 @@ CompilerSet makeprg=./gradlew
 CompilerSet errorformat=
     \%E[ant:scalac]\ %f:%l:\ error:\ %m,
     \%W[ant:scalac]\ %f:%l:\ warning:\ %m,
-    \%E%.%#:compile%.%#Java%f:%l:\ error:\ %m,%-Z%p^,%-C%.%#,
-    \%W%.%#:compile%.%#Java%f:%l:\ warning:\ %m,%-Z%p^,%-C%.%#,
+    \%E%.%#:compile%\\w%#Java%f:%l:\ error:\ %m,%-Z%p^,%-C%.%#,
+    \%W%.%#:compile%\\w%#Java%f:%l:\ warning:\ %m,%-Z%p^,%-C%.%#,
     \%E%f:%l:\ error:\ %m,%-Z%p^,%-C%.%#,
     \%W%f:%l:\ warning:\ %m,%-Z%p^,%-C%.%#,
     \%E%f:\ %\\d%\\+:\ %m\ @\ line\ %l\\,\ column\ %c.,%-C%.%#,%Z%p^,

--- a/compiler/gradlew.vim
+++ b/compiler/gradlew.vim
@@ -15,6 +15,9 @@ CompilerSet makeprg=./gradlew
 CompilerSet errorformat=
     \%E[ant:scalac]\ %f:%l:\ error:\ %m,
     \%W[ant:scalac]\ %f:%l:\ warning:\ %m,
+    \%E:compileJava%f:%l:\ %m,
+    \%E:compileTestJava%f:%l:\ %m,
+    \%E%f:%l:\ %m,%-Z%p^,%-C%.%#,%-G%.%#,
     \%E%f:\ %\\d%\\+:\ %m\ @\ line\ %l\\,\ column\ %c.,%-C%.%#,%Z%p^,
     \%E%>%f:\ %\\d%\\+:\ %m,%C\ @\ line\ %l\\,\ column\ %c.,%-C%.%#,%Z%p^,
     \%-G\\s%#,
@@ -22,4 +25,3 @@ CompilerSet errorformat=
     \%-GTotal\ \time:\ %.%#,
     \%E%f:%l:\ %m,
     \%-G%.%#
-


### PR DESCRIPTION
I found some issues when testing out PR #8. These are some extra improvements to enable the quickfix detection when building with `gradle` and `gradlew`. 
